### PR TITLE
Added duplication legend reduction for regardless of source.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Updated drab_volcano alias list
 - Updated validation submodule head
 - Updated validation pipeline step
+- Fixed bug with duplicate legends in maps causing 0 validation scores for some legend items
 
 ## [0.4.2] - 2024-05-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Updated validation submodule head
 - Updated validation pipeline step
 - Fixed bug with duplicate legends in maps causing 0 validation scores for some legend items
+- Added graph of validation scores for full dataset
 
 ## [0.4.2] - 2024-05-10
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -305,6 +305,12 @@ def main():
         os.makedirs(args.output)
     if args.feedback is not None and not os.path.exists(args.feedback):
         os.makedirs(args.feedback)
+        
+    # Delete old validation result file if it exists
+    if args.validation:
+        full_csv_path = os.path.join(args.output, '#validation_scores.csv')
+        if os.path.exists(full_csv_path):
+            os.remove(full_csv_path)
 
     if args.amqp:
         run_in_amqp_mode(args)

--- a/src/pipeline_steps.py
+++ b/src/pipeline_steps.py
@@ -88,6 +88,13 @@ def gen_legend(data_id, map_data:CMAAS_Map, max_legends=300, drab_volcano_legend
             lgd = extractLegends(image.transpose(1,2,0))
             map_data.legend = convertLegendtoCMASS(lgd)
 
+    # Reduce duplicates
+    legend_features = {}
+    for feature in map_data.legend.features:
+        legend_features[feature.label] = feature
+
+    map_data.legend.features = list(legend_features.values())
+
     # Count distribution of map units for log.
     pt, ln, py, un = 0,0,0,0
     for feature in map_data.legend.features:

--- a/src/pipeline_steps.py
+++ b/src/pipeline_steps.py
@@ -340,6 +340,7 @@ def validation(data_id, map_data: CMAAS_Map, true_mask_dir, output_dir, feedback
             if not alias_found:
                 pipeline_manager.log(logging.WARNING, f'{map_data.name} - Can\'t validate feature {feature.label}. No true segmentation mask found at {true_mask_path}.', pid=mp.current_process().pid)
                 results_df.loc[len(results_df)] = {'Map' : map_data.name, 'Feature' : feature.label}
+                legend_index += 1
                 continue
         true_mask, _, _ = io.loadGeoTiff(true_mask_path)
 


### PR DESCRIPTION
Addressing an issue where map units could become mislabeled due to duplicate map units in the legend. Tested on TX_Driftwood_Wimberley to confirm changes.

Scores before fix : 
<img width="1206" alt="Screenshot 2024-06-11 at 5 26 39 PM" src="https://github.com/DARPA-CRITICALMAAS/uiuc-pipeline/assets/54557445/60939d68-3ef5-4be9-b054-4ad133111e94">


Scores post fix : 
<img width="1206" alt="Screenshot 2024-06-11 at 5 27 23 PM" src="https://github.com/DARPA-CRITICALMAAS/uiuc-pipeline/assets/54557445/f8569d77-e756-484e-a09c-d7468cc01543">

