### PR TITLE
Docker quick build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pip<24
 rasterio>=1.3.9
 geopandas
 --extra-index-url https://test.pypi.org/simple/
-cmaas_utils==0.1.12
+cmaas_utils==0.1.13
 
 # AMQP
 pika


### PR DESCRIPTION
This is a test for speeding up the docker builds by moving cmaas_utils to its own layer of the docker container so that most of the requirements can be cashed. 